### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/extra/demo/manage.py
+++ b/extra/demo/manage.py
@@ -13,7 +13,7 @@ try:
     imp.find_module('settings') # Assumed to be in the same directory.
 except ImportError:
     import sys
-    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n" % __file__)
+    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing {0!r}. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n".format(__file__))
     sys.exit(1)
 
 import settings

--- a/sample_app/__init__.py
+++ b/sample_app/__init__.py
@@ -21,9 +21,9 @@ django-sample-app - A Django app with setup, unittests, docs and a demo site.
 VERSION = (0, 1) # following PEP 386
 
 def get_version():
-    version = '%s.%s' % (VERSION[0], VERSION[1])
+    version = '{0!s}.{1!s}'.format(VERSION[0], VERSION[1])
     if VERSION[2]:
-        version = '%s.%s' % (version, VERSION[2])
+        version = '{0!s}.{1!s}'.format(version, VERSION[2])
     if VERSION[3] != 'f':
-        version = '%s%s%s' % (version, VERSION[3], VERSION[4])
+        version = '{0!s}{1!s}{2!s}'.format(version, VERSION[3], VERSION[4])
     return version


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:iiitmanikanta:django-sample-app?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:iiitmanikanta:django-sample-app?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
